### PR TITLE
Add simple CLI todo app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+tasks.json

--- a/README.md
+++ b/README.md
@@ -1,1 +1,29 @@
 # airclub_ogura
+
+This repository provides a simple command line Todo application written in Python.
+
+## Usage
+
+Add a task:
+
+```
+python todo.py add "Buy milk"
+```
+
+List tasks:
+
+```
+python todo.py list
+```
+
+Mark a task as done (by number):
+
+```
+python todo.py done 1
+```
+
+Delete a task:
+
+```
+python todo.py delete 1
+```

--- a/todo.py
+++ b/todo.py
@@ -1,0 +1,84 @@
+import json
+import os
+import sys
+
+DATA_FILE = 'tasks.json'
+
+def load_tasks():
+    if os.path.exists(DATA_FILE):
+        with open(DATA_FILE, 'r', encoding='utf-8') as f:
+            return json.load(f)
+    return []
+
+def save_tasks(tasks):
+    with open(DATA_FILE, 'w', encoding='utf-8') as f:
+        json.dump(tasks, f, ensure_ascii=False, indent=2)
+
+def list_tasks():
+    tasks = load_tasks()
+    if not tasks:
+        print('No tasks.')
+    else:
+        for idx, t in enumerate(tasks, 1):
+            status = '✓' if t.get('done') else ' '
+            print(f"{idx}. [{status}] {t['text']}")
+
+def add_task(text):
+    tasks = load_tasks()
+    tasks.append({'text': text, 'done': False})
+    save_tasks(tasks)
+    print('Task added.')
+
+def complete_task(index):
+    tasks = load_tasks()
+    if 0 <= index < len(tasks):
+        tasks[index]['done'] = True
+        save_tasks(tasks)
+        print('Task completed.')
+    else:
+        print('Invalid task number.')
+
+def delete_task(index):
+    tasks = load_tasks()
+    if 0 <= index < len(tasks):
+        tasks.pop(index)
+        save_tasks(tasks)
+        print('Task deleted.')
+    else:
+        print('Invalid task number.')
+
+def usage():
+    print("Usage: python todo.py [list|add TEXT|done NUMBER|delete NUMBER]")
+
+if __name__ == '__main__':
+    if len(sys.argv) < 2:
+        usage()
+    else:
+        cmd = sys.argv[1]
+        if cmd == 'list':
+            list_tasks()
+        elif cmd == 'add':
+            if len(sys.argv) < 3:
+                print('Provide task text.')
+            else:
+                add_task(' '.join(sys.argv[2:]))
+        elif cmd == 'done':
+            if len(sys.argv) < 3:
+                print('Provide task number.')
+            else:
+                try:
+                    index = int(sys.argv[2]) - 1
+                    complete_task(index)
+                except ValueError:
+                    print('Provide a number.')
+        elif cmd == 'delete':
+            if len(sys.argv) < 3:
+                print('Provide task number.')
+            else:
+                try:
+                    index = int(sys.argv[2]) - 1
+                    delete_task(index)
+                except ValueError:
+                    print('Provide a number.')
+        else:
+            usage()


### PR DESCRIPTION
## Summary
- add a python-based todo CLI
- ignore generated `tasks.json`
- expand README with instructions

## Testing
- `python3 todo.py list`

------
https://chatgpt.com/codex/tasks/task_e_684b8d98f4188331935b3ab58a4e91aa