### PR TITLE
Rewrite todo app as Spring Boot API with Docker support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.git
+target
+tasks.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+tasks.json
+*.class
+target/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+# Build stage
+FROM maven:3.9.6-eclipse-temurin-21 AS build
+WORKDIR /app
+COPY pom.xml .
+RUN mvn -q dependency:go-offline
+COPY src ./src
+RUN mvn -q package -DskipTests
+
+# Runtime stage
+FROM eclipse-temurin:21-jre
+WORKDIR /app
+COPY --from=build /app/target/todo-0.0.1-SNAPSHOT.jar app.jar
+EXPOSE 8080
+ENTRYPOINT ["java","-jar","app.jar"]

--- a/README.md
+++ b/README.md
@@ -1,1 +1,38 @@
 # airclub_ogura
+
+This repository now contains a simple Todo REST API built with Spring Boot.
+
+## Building and running locally
+
+Compile and run the application using Maven:
+
+```bash
+mvn spring-boot:run
+```
+
+Alternatively, build the jar and run it with Java:
+
+```bash
+mvn package -DskipTests
+java -jar target/todo-0.0.1-SNAPSHOT.jar
+```
+
+The service exposes HTTP endpoints on port `8080`:
+
+- `GET /tasks` – list tasks
+- `POST /tasks` – add a task `{ "text": "Buy milk" }`
+- `PUT /tasks/{id}/done` – mark a task as done
+- `DELETE /tasks/{id}` – delete a task
+
+Tasks are persisted to `tasks.json` in the working directory.
+
+## Docker usage
+
+Build the Docker image and run the container:
+
+```bash
+docker build -t todo-app .
+docker run -p 8080:8080 todo-app
+```
+
+You can then interact with the API on `http://localhost:8080`.

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,31 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.2.5</version>
+        <relativePath/>
+    </parent>
+    <groupId>com.example</groupId>
+    <artifactId>todo</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <name>todo</name>
+    <properties>
+        <java.version>21</java.version>
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/main/java/com/example/todo/Task.java
+++ b/src/main/java/com/example/todo/Task.java
@@ -1,0 +1,39 @@
+package com.example.todo;
+
+public class Task {
+    private int id;
+    private String text;
+    private boolean done;
+
+    public Task() {}
+
+    public Task(int id, String text, boolean done) {
+        this.id = id;
+        this.text = text;
+        this.done = done;
+    }
+
+    public int getId() {
+        return id;
+    }
+
+    public void setId(int id) {
+        this.id = id;
+    }
+
+    public String getText() {
+        return text;
+    }
+
+    public void setText(String text) {
+        this.text = text;
+    }
+
+    public boolean isDone() {
+        return done;
+    }
+
+    public void setDone(boolean done) {
+        this.done = done;
+    }
+}

--- a/src/main/java/com/example/todo/TaskController.java
+++ b/src/main/java/com/example/todo/TaskController.java
@@ -1,0 +1,44 @@
+package com.example.todo;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/tasks")
+public class TaskController {
+    private final TaskService service;
+
+    public TaskController(TaskService service) {
+        this.service = service;
+    }
+
+    @GetMapping
+    public List<Task> list() {
+        return service.list();
+    }
+
+    @PostMapping
+    public Task add(@RequestBody Task request) {
+        return service.add(request.getText());
+    }
+
+    @PutMapping("/{id}/done")
+    public ResponseEntity<Task> done(@PathVariable int id) {
+        Task t = service.complete(id);
+        if (t == null) {
+            return ResponseEntity.notFound().build();
+        }
+        return ResponseEntity.ok(t);
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> delete(@PathVariable int id) {
+        boolean removed = service.delete(id);
+        if (removed) {
+            return ResponseEntity.noContent().build();
+        }
+        return ResponseEntity.notFound().build();
+    }
+}

--- a/src/main/java/com/example/todo/TaskService.java
+++ b/src/main/java/com/example/todo/TaskService.java
@@ -1,0 +1,77 @@
+package com.example.todo;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.stereotype.Service;
+
+import javax.annotation.PostConstruct;
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+@Service
+public class TaskService {
+    private static final String DATA_FILE = "tasks.json";
+    private final ObjectMapper mapper = new ObjectMapper();
+    private final List<Task> tasks = new ArrayList<>();
+    private final AtomicInteger counter = new AtomicInteger();
+
+    @PostConstruct
+    private void init() {
+        loadTasks();
+    }
+
+    public synchronized List<Task> list() {
+        return new ArrayList<>(tasks);
+    }
+
+    public synchronized Task add(String text) {
+        Task t = new Task(counter.incrementAndGet(), text, false);
+        tasks.add(t);
+        saveTasks();
+        return t;
+    }
+
+    public synchronized Task complete(int id) {
+        for (Task t : tasks) {
+            if (t.getId() == id) {
+                t.setDone(true);
+                saveTasks();
+                return t;
+            }
+        }
+        return null;
+    }
+
+    public synchronized boolean delete(int id) {
+        boolean removed = tasks.removeIf(t -> t.getId() == id);
+        if (removed) {
+            saveTasks();
+        }
+        return removed;
+    }
+
+    private void loadTasks() {
+        try {
+            File f = new File(DATA_FILE);
+            if (f.exists()) {
+                List<Task> loaded = mapper.readValue(f, new TypeReference<List<Task>>() {});
+                tasks.clear();
+                tasks.addAll(loaded);
+                int maxId = tasks.stream().mapToInt(Task::getId).max().orElse(0);
+                counter.set(maxId);
+            }
+        } catch (Exception e) {
+            System.err.println("Failed to load tasks: " + e.getMessage());
+        }
+    }
+
+    private void saveTasks() {
+        try {
+            mapper.writerWithDefaultPrettyPrinter().writeValue(new File(DATA_FILE), tasks);
+        } catch (Exception e) {
+            System.err.println("Failed to save tasks: " + e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/example/todo/TodoApplication.java
+++ b/src/main/java/com/example/todo/TodoApplication.java
@@ -1,0 +1,11 @@
+package com.example.todo;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class TodoApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(TodoApplication.class, args);
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+# default port 8080


### PR DESCRIPTION
## Summary
- replace CLI-based Java app with a Spring Boot REST API
- persist tasks to `tasks.json`
- add Dockerfile and `.dockerignore`
- update `.gitignore`
- document API usage and Docker instructions

## Testing
- `javac src/main/java/com/example/todo/TodoApplication.java` *(fails: package org.springframework.boot does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_684b8d98f4188331935b3ab58a4e91aa